### PR TITLE
Update mock data to use volleyball and futsal sports

### DIFF
--- a/features/schedule/src/commonMain/kotlin/pt/dourobats/app/features/schedule/data/MockSessionData.kt
+++ b/features/schedule/src/commonMain/kotlin/pt/dourobats/app/features/schedule/data/MockSessionData.kt
@@ -26,7 +26,7 @@ object MockSessionData {
             // Today's sessions
             createSession(
                 id = "session-1",
-                sportName = "Baseball",
+                sportName = "Volleyball",
                 date = baseDate,
                 startTime = LocalTime(18, 0),
                 durationHours = 2.0,
@@ -36,7 +36,7 @@ object MockSessionData {
             ),
             createSession(
                 id = "session-2",
-                sportName = "Softball",
+                sportName = "Futsal",
                 date = baseDate,
                 startTime = LocalTime(20, 30),
                 durationHours = 1.5,
@@ -48,7 +48,7 @@ object MockSessionData {
             // Tomorrow's sessions
             createSession(
                 id = "session-3",
-                sportName = "Baseball",
+                sportName = "Volleyball",
                 date = baseDate.plusDays(1),
                 startTime = LocalTime(19, 0),
                 durationHours = 2.0,
@@ -60,7 +60,7 @@ object MockSessionData {
             // Week ahead sessions
             createSession(
                 id = "session-4",
-                sportName = "Baseball",
+                sportName = "Volleyball",
                 date = baseDate.plusDays(3),
                 startTime = LocalTime(18, 0),
                 durationHours = 2.0,
@@ -70,7 +70,7 @@ object MockSessionData {
             ),
             createSession(
                 id = "session-5",
-                sportName = "Softball",
+                sportName = "Futsal",
                 date = baseDate.plusDays(5),
                 startTime = LocalTime(17, 0),
                 durationHours = 2.0,
@@ -125,13 +125,13 @@ fun List<Session>.toDisplayData(bookedIds: Set<String>): List<SessionDisplayData
         SessionDisplayData(
             session = session,
             sportName = when (session.sportId) {
-                "baseball" -> "Baseball"
-                "softball" -> "Softball"
+                "volleyball" -> "Volleyball"
+                "futsal" -> "Futsal"
                 else -> "Unknown"
             },
             sportIcon = when (session.sportId) {
-                "baseball" -> "⚾"
-                "softball" -> "🥎"
+                "volleyball" -> "🏐"
+                "futsal" -> "⚽"
                 else -> "🏃"
             },
             venueName = session.venueId,

--- a/features/schedule/src/commonTest/kotlin/pt/dourobats/app/features/schedule/data/MockSessionDataTest.kt
+++ b/features/schedule/src/commonTest/kotlin/pt/dourobats/app/features/schedule/data/MockSessionDataTest.kt
@@ -132,7 +132,7 @@ class MockSessionDataTest {
     }
 
     @Test
-    fun `toDisplayData maps baseball to correct icon and name`() {
+    fun `toDisplayData maps volleyball to correct icon and name`() {
         // Arrange
         val sessions = MockSessionData.generateMockSessions()
         val bookedIds = MockSessionData.getUserBookedSessionIds()
@@ -141,15 +141,15 @@ class MockSessionDataTest {
         val displayData = sessions.toDisplayData(bookedIds)
 
         // Assert
-        val baseballSessions = displayData.filter { it.session.sportId == "baseball" }
-        baseballSessions.forEach { data ->
-            assertEquals("Baseball", data.sportName, "Baseball should have correct name")
-            assertEquals("⚾", data.sportIcon, "Baseball should have correct icon")
+        val volleyballSessions = displayData.filter { it.session.sportId == "volleyball" }
+        volleyballSessions.forEach { data ->
+            assertEquals("Volleyball", data.sportName, "Volleyball should have correct name")
+            assertEquals("🏐", data.sportIcon, "Volleyball should have correct icon")
         }
     }
 
     @Test
-    fun `toDisplayData maps softball to correct icon and name`() {
+    fun `toDisplayData maps futsal to correct icon and name`() {
         // Arrange
         val sessions = MockSessionData.generateMockSessions()
         val bookedIds = MockSessionData.getUserBookedSessionIds()
@@ -158,10 +158,10 @@ class MockSessionDataTest {
         val displayData = sessions.toDisplayData(bookedIds)
 
         // Assert
-        val softballSessions = displayData.filter { it.session.sportId == "softball" }
-        softballSessions.forEach { data ->
-            assertEquals("Softball", data.sportName, "Softball should have correct name")
-            assertEquals("🥎", data.sportIcon, "Softball should have correct icon")
+        val futsalSessions = displayData.filter { it.session.sportId == "futsal" }
+        futsalSessions.forEach { data ->
+            assertEquals("Futsal", data.sportName, "Futsal should have correct name")
+            assertEquals("⚽", data.sportIcon, "Futsal should have correct icon")
         }
     }
 


### PR DESCRIPTION
- Replace baseball with volleyball (🏐)
- Replace softball with futsal (⚽)
- Update all session mock data to reflect new sports
- Update tests to validate volleyball and futsal mappings
- All tests passing